### PR TITLE
Add items to tray

### DIFF
--- a/burger.gd
+++ b/burger.gd
@@ -12,8 +12,7 @@ func _process(delta: float) -> void:
 	if dragging: 
 		position = get_global_mouse_position() - offset
 	elif garbage:
-		free()
-
+		queue_free()
 
 func _on_button_button_down() -> void:
 	if in_holder:

--- a/burger.tscn
+++ b/burger.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=4 format=3 uid="uid://bqkr6lg28uv5f"]
+[gd_scene load_steps=5 format=3 uid="uid://bqkr6lg28uv5f"]
 
 [ext_resource type="Script" path="res://burger.gd" id="1_qtw7p"]
 [ext_resource type="Texture2D" uid="uid://qsh4d15rgnwt" path="res://Art/Raw Patty.png" id="2_7gm67"]
+[ext_resource type="Script" path="res://item_ref.gd" id="3_37v4n"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_u3uuq"]
 radius = 40.05
@@ -20,12 +21,14 @@ offset_top = -40.0
 offset_right = 39.0
 offset_bottom = 39.0
 
-[node name="Area2D" type="Area2D" parent="."]
+[node name="BurgerArea2D" type="Area2D" parent="." node_paths=PackedStringArray("item_ref")]
+script = ExtResource("3_37v4n")
+item_ref = NodePath("..")
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="BurgerArea2D"]
 shape = SubResource("CircleShape2D_u3uuq")
 
 [connection signal="button_down" from="Button" to="." method="_on_button_button_down"]
 [connection signal="button_up" from="Button" to="." method="_on_button_button_up"]
-[connection signal="body_entered" from="Area2D" to="." method="_on_area_2d_body_entered"]
-[connection signal="body_exited" from="Area2D" to="." method="_on_area_2d_body_exited"]
+[connection signal="body_entered" from="BurgerArea2D" to="." method="_on_area_2d_body_entered"]
+[connection signal="body_exited" from="BurgerArea2D" to="." method="_on_area_2d_body_exited"]

--- a/burger.tscn
+++ b/burger.tscn
@@ -5,7 +5,7 @@
 [ext_resource type="Script" path="res://item_ref.gd" id="3_37v4n"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_u3uuq"]
-radius = 40.05
+radius = 4.24264
 
 [node name="Burger" type="Node2D"]
 script = ExtResource("1_qtw7p")

--- a/game_scene.tscn
+++ b/game_scene.tscn
@@ -126,11 +126,10 @@ scale = Vector2(107.812, 176.75)
 texture = SubResource("CanvasTexture_njqb8")
 metadata/_edit_lock_ = true
 
-[node name="StaticBody2D" type="StaticBody2D" parent="OrderTray1/Sprite2D"]
-scale = Vector2(0.0115607, 0.0141844)
-metadata/_edit_lock_ = true
+[node name="Area2D" type="Area2D" parent="OrderTray1"]
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="OrderTray1/Sprite2D/StaticBody2D"]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="OrderTray1/Area2D"]
+scale = Vector2(1.24638, 2.50709)
 shape = SubResource("RectangleShape2D_fcc7r")
 metadata/_edit_lock_ = true
 
@@ -168,3 +167,15 @@ grow_vertical = 0
 text = "Garbage"
 label_settings = SubResource("LabelSettings_j46k3")
 horizontal_alignment = 1
+
+[node name="Button" type="Button" parent="."]
+offset_left = 376.0
+offset_top = 428.0
+offset_right = 484.0
+offset_bottom = 451.0
+text = "Complete"
+
+[connection signal="complete_order1" from="OrderTray1" to="Order1" method="_on_order_tray_1_complete_order_1"]
+[connection signal="area_entered" from="OrderTray1/Area2D" to="OrderTray1" method="_on_area_2d_area_entered"]
+[connection signal="area_exited" from="OrderTray1/Area2D" to="OrderTray1" method="_on_area_2d_area_exited"]
+[connection signal="button_up" from="Button" to="OrderTray1" method="_on_button_button_up"]

--- a/game_scene.tscn
+++ b/game_scene.tscn
@@ -133,8 +133,62 @@ scale = Vector2(1.24638, 2.50709)
 shape = SubResource("RectangleShape2D_fcc7r")
 metadata/_edit_lock_ = true
 
-[node name="Burger" parent="." instance=ExtResource("5_pqdkt")]
-position = Vector2(56, 275)
+[node name="Button" type="Button" parent="OrderTray1"]
+offset_left = -54.0
+offset_top = 91.0
+offset_right = 54.0
+offset_bottom = 122.0
+text = "Complete"
+
+[node name="OrderTray2" type="Node2D" parent="." node_paths=PackedStringArray("order_node")]
+position = Vector2(560, 337)
+script = ExtResource("4_3t63p")
+order_node = NodePath("../Order2")
+
+[node name="Sprite2D" type="Sprite2D" parent="OrderTray2"]
+modulate = Color(0.564962, 0.564962, 0.564962, 1)
+scale = Vector2(107.812, 176.75)
+texture = SubResource("CanvasTexture_njqb8")
+metadata/_edit_lock_ = true
+
+[node name="Area2D" type="Area2D" parent="OrderTray2"]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="OrderTray2/Area2D"]
+scale = Vector2(1.24638, 2.50709)
+shape = SubResource("RectangleShape2D_fcc7r")
+metadata/_edit_lock_ = true
+
+[node name="Button" type="Button" parent="OrderTray2"]
+offset_left = -54.0
+offset_top = 91.0
+offset_right = 54.0
+offset_bottom = 122.0
+text = "Complete"
+
+[node name="OrderTray3" type="Node2D" parent="." node_paths=PackedStringArray("order_node")]
+position = Vector2(690, 337)
+script = ExtResource("4_3t63p")
+order_node = NodePath("../Order3")
+
+[node name="Sprite2D" type="Sprite2D" parent="OrderTray3"]
+modulate = Color(0.564962, 0.564962, 0.564962, 1)
+scale = Vector2(107.812, 176.75)
+texture = SubResource("CanvasTexture_njqb8")
+metadata/_edit_lock_ = true
+
+[node name="Area2D" type="Area2D" parent="OrderTray3"]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="OrderTray3/Area2D"]
+scale = Vector2(1.24638, 2.50709)
+shape = SubResource("RectangleShape2D_fcc7r")
+metadata/_edit_lock_ = true
+
+[node name="Button" type="Button" parent="OrderTray3"]
+offset_left = -54.0
+offset_top = 91.0
+offset_right = 54.0
+offset_bottom = 122.0
+text = "Complete"
 
 [node name="Garbage" type="StaticBody2D" parent="."]
 position = Vector2(1068, 530)
@@ -168,14 +222,15 @@ text = "Garbage"
 label_settings = SubResource("LabelSettings_j46k3")
 horizontal_alignment = 1
 
-[node name="Button" type="Button" parent="."]
-offset_left = 376.0
-offset_top = 428.0
-offset_right = 484.0
-offset_bottom = 451.0
-text = "Complete"
+[node name="Burger" parent="." instance=ExtResource("5_pqdkt")]
+position = Vector2(56, 275)
 
-[connection signal="complete_order1" from="OrderTray1" to="Order1" method="_on_order_tray_1_complete_order_1"]
 [connection signal="area_entered" from="OrderTray1/Area2D" to="OrderTray1" method="_on_area_2d_area_entered"]
 [connection signal="area_exited" from="OrderTray1/Area2D" to="OrderTray1" method="_on_area_2d_area_exited"]
-[connection signal="button_up" from="Button" to="OrderTray1" method="_on_button_button_up"]
+[connection signal="button_up" from="OrderTray1/Button" to="OrderTray1" method="_on_button_button_up"]
+[connection signal="area_entered" from="OrderTray2/Area2D" to="OrderTray2" method="_on_area_2d_area_entered"]
+[connection signal="area_exited" from="OrderTray2/Area2D" to="OrderTray2" method="_on_area_2d_area_exited"]
+[connection signal="button_up" from="OrderTray2/Button" to="OrderTray2" method="_on_button_button_up"]
+[connection signal="area_entered" from="OrderTray3/Area2D" to="OrderTray3" method="_on_area_2d_area_entered"]
+[connection signal="area_exited" from="OrderTray3/Area2D" to="OrderTray3" method="_on_area_2d_area_exited"]
+[connection signal="button_up" from="OrderTray3/Button" to="OrderTray3" method="_on_button_button_up"]

--- a/item_ref.gd
+++ b/item_ref.gd
@@ -1,0 +1,3 @@
+extends Area2D
+
+@export var item_ref : Node2D #This reference is needed to be able to delete the whole object

--- a/main.gd
+++ b/main.gd
@@ -3,7 +3,8 @@ extends Node
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
-	pass
+	$Order1.order = ["Burger", "Burger"]
+	$Order1._set_label_text()
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta: float) -> void:

--- a/main.gd
+++ b/main.gd
@@ -5,6 +5,10 @@ extends Node
 func _ready() -> void:
 	$Order1.order = ["Burger", "Burger"]
 	$Order1._set_label_text()
+	$Order2.order = ["Burger", "Burger"]
+	$Order2._set_label_text()
+	$Order3.order = ["Burger", "Burger"]
+	$Order3._set_label_text()
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta: float) -> void:

--- a/order.gd
+++ b/order.gd
@@ -21,8 +21,3 @@ func _clear_label():
 #On customer leaves, clear the label
 
 #On new customer enters, generate new order
-	
-
-
-func _on_order_tray_1_complete_order_1() -> void:
-	_generate_order()

--- a/order.gd
+++ b/order.gd
@@ -22,3 +22,7 @@ func _clear_label():
 
 #On new customer enters, generate new order
 	
+
+
+func _on_order_tray_1_complete_order_1() -> void:
+	_generate_order()

--- a/order_tray.gd
+++ b/order_tray.gd
@@ -2,16 +2,17 @@ extends Node2D
 
 @export var order_node : Node2D
 var items_in_tray = Array()
-	
+signal complete_order1
+
 func _is_order_complete() -> bool:
 	#Simple first check to see if the number of items is the same
 	if items_in_tray.size() != order_node.order.size():
 		return false
 		
 	#Check that there are the correct number of anything
-	var unchecked_objects = items_in_tray
+	var unchecked_objects = items_in_tray.duplicate()
 	for item in order_node.order:
-		var object_item : Node2D #Null, otherwise an object in the tray with the name of something on the order
+		var object_item : Area2D #Null, otherwise an object in the tray with the name of something on the order
 		for object in unchecked_objects:
 			if object.name.contains(item):
 				object_item = object #This is an object that exists in the tray and that is on the order
@@ -21,9 +22,30 @@ func _is_order_complete() -> bool:
 			return false #An object is on the tray that is not part of the order
 	return true
 	
+func _try_to_complete_order():
+	if _is_order_complete() == true: _complete_order()
+	
 func _complete_order():
 	for item in items_in_tray:
-		item.free()
+		item.item_ref.garbage = true
+	emit_signal("complete_order1")
 		
-func _add_item_to_tray(item : Node2D):
+func _add_item_to_tray(item : Area2D):
 	items_in_tray.append(item)
+	print_debug(items_in_tray)
+
+func _remove_item_from_tray(item : Area2D):
+	items_in_tray.erase(item)
+	print_debug(items_in_tray)
+
+func _on_area_2d_area_entered(area: Area2D) -> void:
+	_add_item_to_tray(area)
+	print_debug("added")
+
+func _on_area_2d_area_exited(area: Area2D) -> void:
+	_remove_item_from_tray(area)
+	print_debug("removed")
+
+
+func _on_button_button_up() -> void:
+	_try_to_complete_order()

--- a/order_tray.gd
+++ b/order_tray.gd
@@ -2,7 +2,7 @@ extends Node2D
 
 @export var order_node : Node2D
 var items_in_tray = Array()
-signal complete_order1
+signal complete_order
 
 func _is_order_complete() -> bool:
 	#Simple first check to see if the number of items is the same
@@ -28,7 +28,8 @@ func _try_to_complete_order():
 func _complete_order():
 	for item in items_in_tray:
 		item.item_ref.garbage = true
-	emit_signal("complete_order1")
+	order_node._generate_order() #Remove after adding customers
+	emit_signal("complete_order")
 		
 func _add_item_to_tray(item : Area2D):
 	items_in_tray.append(item)


### PR DESCRIPTION
Items can be added to one of three trays. Each tray has a complete order button that, when pressed, checks if the contents of the tray meet the requirements of the order. Items are deleted from the tray when the order is completed. Currently, a new order is generated when the order is completed, but this will be changed later to rely on the customer NPC.